### PR TITLE
Fix bug when site uses Turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ alteis_hagreed:
     template: 'default'
     id: 'hagreed' #Refer to the Installation section.
     timeout: 5000 #The cookie box will launch - if the user has never made a choice - after 5000 ms (5 seconds).
+    turbo: false #If your site uses Turbo, set this to "true".
     cookies: #Insert your cookies here
         -
             id: ga

--- a/config/services.php
+++ b/config/services.php
@@ -16,6 +16,7 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$element', '%alteis_hagreed.element%')
         ->arg('$cookies', '%alteis_hagreed.cookies%')
         ->arg('$timeout', '%alteis_hagreed.timeout%')
+        ->arg('$turbo', '%alteis_hagreed.turbo%')
         ->arg('$language', '%alteis_hagreed.language%')
         ->arg('$consentsFormList', '%alteis_hagreed.consents_form_list%')
         ->autowire()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('token')->defaultNull()->end()
                     ->integerNode('timeout')->defaultValue(5000)->end()
                     ->enumNode('template')->values(['default', 'fullpage', 'custom'])->defaultNull()->end()
+                    ->booleanNode('turbo')->defaultFalse()->end()
 
                     ->arrayNode('language')
                         ->children()

--- a/src/DependencyInjection/DependencyInjection.php
+++ b/src/DependencyInjection/DependencyInjection.php
@@ -27,6 +27,7 @@ class DependencyInjection extends Extension
         $container->setParameter('alteis_hagreed.token', $config['token']);
         $container->setParameter('alteis_hagreed.cookies', $config['cookies']);
         $container->setParameter('alteis_hagreed.timeout', $config['timeout']);
+        $container->setParameter('alteis_hagreed.turbo', $config['turbo']);
         $container->setParameter('alteis_hagreed.consents_form_list', $config['consents_form_list']);
 
         $container->setParameter('alteis_hagreed.language', [

--- a/src/Twig/HagreedExtension.php
+++ b/src/Twig/HagreedExtension.php
@@ -16,6 +16,7 @@ class HagreedExtension extends AbstractExtension
         private readonly array $cookies,
         private readonly array $consentsFormList,
         private readonly int $timeout,
+        private readonly bool $turbo,
         private readonly array $language
     ) {}
 
@@ -35,15 +36,27 @@ class HagreedExtension extends AbstractExtension
         if ($this->token === null) {
             throw new \Exception('token is null');
         }
-        return $this->twig->render('@AlteisHagreed/header.html.twig', [
-            'element' => $this->element,
-            'token' => $this->token,
-            'template' => $this->template,
-            'timeout' => $this->timeout,
-            'language' => $this->language,
-            'cookies' => json_encode($this->cookies),
-            'consentsFormList' => json_encode($this->consentsFormList),
-        ]);
+        if ($this->turbo) {
+            return $this->twig->render('@AlteisHagreed/header_turbo.html.twig', [
+                'element' => $this->element,
+                'token' => $this->token,
+                'template' => $this->template,
+                'timeout' => $this->timeout,
+                'language' => $this->language,
+                'cookies' => json_encode($this->cookies),
+                'consentsFormList' => json_encode($this->consentsFormList),
+            ]);
+        } else {
+            return $this->twig->render('@AlteisHagreed/header.html.twig', [
+                'element' => $this->element,
+                'token' => $this->token,
+                'template' => $this->template,
+                'timeout' => $this->timeout,
+                'language' => $this->language,
+                'cookies' => json_encode($this->cookies),
+                'consentsFormList' => json_encode($this->consentsFormList),
+            ]);
+        }
     }
 
     public function bodyEnd(): string

--- a/templates/header_turbo.html.twig
+++ b/templates/header_turbo.html.twig
@@ -1,0 +1,36 @@
+<link href="{{ asset('vendor/@tizy/hagreed/style.css') }}" rel="stylesheet" />
+<link rel="modulepreload" href="{{ asset('vendor/@tizy/hagreed/hagreed.js') }}">
+<div id="header_hagreed_cookies_consents" data-cookies="{{ cookies }}" data-consents="{{ consentsFormList }}"></div>
+<script type="module">
+
+    import Hagreed from '@tizy/hagreed/hagreed.js';
+    document.addEventListener("turbo:load", () => {
+        if (typeof window.hagreedBundle !== 'undefined') {
+            return;
+        }
+
+        const elementCookiesConsents = document.getElementById('header_hagreed_cookies_consents');
+        const hagreedCookiesList = JSON.parse(elementCookiesConsents.getAttribute('data-cookies')); // cookie list
+        const hagreedConsentsFormList = JSON.parse(elementCookiesConsents.getAttribute('data-consents')); // cookie list
+
+        const hagreedLanguage = {};
+        {% if language['lang'] is not null %}
+        hagreedLanguage.lang = "{{ language['lang'] }}";
+        {% endif %}
+
+        {% if language['force_lang'] is not null %}
+        hagreedLanguage.forceLang = {{ language['force_lang'] ? 'true' : 'false' }};
+        {% endif %}
+
+        window.hagreedBundle = new Hagreed.default("{{ token }}", hagreedLanguage);
+        {% if template is not null %}
+        window.hagreedBundle.template = "{{ template }}";
+        {% endif %}
+        window.hagreedBundle.element = "{{ element }}";
+        window.hagreedBundle.cookiesList = hagreedCookiesList;
+        window.hagreedBundle.consentsFormList = hagreedConsentsFormList;
+        window.hagreedBundle.timeout = {{ timeout }}; // Ce paramètre permet de différer le moment où la boîte des cookies s’ouvre. Cela s’exprime en millisecondes.
+        window.hagreedBundle.init();
+    });
+
+</script>


### PR DESCRIPTION
### description bug:
The consent window always shows up on websites that use Turbo.

### Using HagreeBundle with Turbo:

If your site uses Turbo (Hotwire), make sure to configure HagreeBundle accordingly to prevent the consent window from reappearing on every navigation.
Add the following option to your configuration:
```
alteis_hagreed:
    turbo: true
```
This enables Turbo compatibility and ensures the consent banner doesn't reload on every page transition.